### PR TITLE
Allow ldap_config to set Net::LDAP encryption options

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -12,6 +12,7 @@ module Devise
         ldap_options = params
         ldap_config["ssl"] = :simple_tls if ldap_config["ssl"] === true
         ldap_options[:encryption] = ldap_config["ssl"].to_sym if ldap_config["ssl"]
+        ldap_options[:encryption] = ldap_config["encryption"] if ldap_config["encryption"]
 
         @ldap = Net::LDAP.new(ldap_options)
         @ldap.host = ldap_config["host"]


### PR DESCRIPTION
This PR is same with [Allow tls_options hash to be passed to Net::LDAP #236](https://github.com/cschiewek/devise_ldap_authenticatable/pull/246), but without the test.
The [cschiewek-devise_ldap_authenticatable](https://github.com/cschiewek/devise_ldap_authenticatable) doesn't merge the PR and I want to use the search_by_ldap_attr which didn't merged by [cschiewek-devise_ldap_authenticatable](https://github.com/cschiewek/devise_ldap_authenticatable) either, so I submit this PR.
Thanks.